### PR TITLE
feat: Add useEnsureCorrectChain hook for chain enforcement

### DIFF
--- a/.changeset/nice-baths-design.md
+++ b/.changeset/nice-baths-design.md
@@ -1,0 +1,7 @@
+---
+"@everipedia/iq-login": patch
+---
+
+Add `useEnsureCorrectChain` hook to standardize wallet network enforcement in dApps.
+
+This hook introduces a unified status state machine (`idle` → `wrong-network` → `switching` → `correct`) for managing connected wallet chain state. It includes utilities for programmatic network switching, dismissal handling, and an optional `onStatusChange` callback for reacting to status transitions. Documentation has been added to the README with usage examples and API reference.

--- a/README.md
+++ b/README.md
@@ -144,6 +144,82 @@ if (token && address) {
 }
 ```
 
+## 🔗 Chain Enforcement Hook
+
+Use `useEnsureCorrectChain` to ensure the connected wallet is on the correct network. It exposes a single `status` flow instead of multiple booleans:
+
+```
+idle → wrong-network → switching → correct
+```
+
+| Status | Meaning |
+|---|---|
+| `"idle"` | Wallet not connected or state dismissed |
+| `"wrong-network"` | Connected to an unsupported chain |
+| `"switching"` | Chain switch in progress |
+| `"correct"` | On the required chain |
+
+### Basic Usage
+
+```tsx
+import { useEnsureCorrectChain } from '@everipedia/iq-login/client';
+
+function MyComponent() {
+  const { status, switchToCorrectChain, targetChain, dismiss } = useEnsureCorrectChain({
+    requiredChainId: 252, // e.g. Fraxtal
+  });
+
+  if (status === "wrong-network") {
+    return (
+      <div>
+        <p>Please switch to {targetChain?.name}</p>
+        <button onClick={switchToCorrectChain}>Switch Network</button>
+        <button onClick={dismiss}>Dismiss</button>
+      </div>
+    );
+  }
+
+  if (status === "switching") {
+    return <p>Switching network...</p>;
+  }
+
+  return <p>Connected to the correct network!</p>;
+}
+```
+
+### With Status Callback
+
+Use `onStatusChange` to react to transitions — e.g. to open/close a modal:
+
+```tsx
+const { status, switchToCorrectChain } = useEnsureCorrectChain({
+  requiredChainId: 252,
+  onStatusChange: (status, chainName) => {
+    if (status === "wrong-network") openSwitchModal();
+    if (status === "correct") closeSwitchModal();
+  },
+});
+```
+
+### API Reference
+
+**Options:**
+
+| Prop | Type | Description |
+|---|---|---|
+| `requiredChainId` | `number` | The chain ID your app requires |
+| `onStatusChange` | `(status, chainName?) => void` | Optional callback on every status transition |
+
+**Returns:**
+
+| Field | Type | Description |
+|---|---|---|
+| `status` | `ChainStatus` | Current status (`"idle"`, `"wrong-network"`, `"switching"`, `"correct"`) |
+| `switchToCorrectChain` | `() => Promise<void>` | Trigger a chain switch |
+| `dismiss` | `() => void` | Dismiss the wrong-network state |
+| `targetChain` | `Chain \| undefined` | Target chain object from wagmi config |
+| `isConnected` | `boolean` | Whether the wallet is connected |
+
 ## 🎨 Styling
 
 The package uses Tailwind CSS and Shadcn UI Theme. Visit https://ui.shadcn.com/themes for theme customization.

--- a/src/client.ts
+++ b/src/client.ts
@@ -12,6 +12,12 @@ export { Login } from "./components/login-element";
 // ===============
 export { useAuth } from "./hooks/use-auth";
 export { useWeb3Auth } from "./hooks/use-web-3-auth";
+export {
+	useEnsureCorrectChain,
+	type ChainStatus,
+	type UseEnsureCorrectChainOptions,
+	type UseEnsureCorrectChainReturn,
+} from "./hooks/use-ensure-correct-chain";
 
 // ===============
 // Config

--- a/src/hooks/use-ensure-correct-chain.ts
+++ b/src/hooks/use-ensure-correct-chain.ts
@@ -52,35 +52,38 @@ export const useEnsureCorrectChain = ({
 		transition(chainId === requiredChainId ? "correct" : "wrong-network");
 	}, [chainId, isConnected, requiredChainId, transition]);
 
-	const switchToCorrectChain = async () => {
-		if (!chainId) {
-			throw new Error(
-				"Wallet is not connected. Please connect your wallet first.",
-			);
+	const switchToCorrectChain = useCallback(async () => {
+		if (!isConnected) {
+			console.error("Cannot switch chain, wallet not connected.");
+			return;
 		}
 
 		if (chainId === requiredChainId) return;
 
 		if (!targetChain) {
-			throw new Error(
-				`Chain ID ${requiredChainId} is not configured in your wallet.`,
+			console.error(
+				`Cannot switch chain, target chain with ID ${requiredChainId} is not configured.`,
 			);
+			return;
 		}
 
 		try {
 			transition("switching");
 			await switchChainAsync({ chainId: requiredChainId });
-			transition("correct");
 		} catch (error) {
 			console.error("Failed to switch network:", error);
 			transition("wrong-network");
-			throw new Error(
-				"Network switch failed. Please switch manually in your wallet.",
-			);
 		}
-	};
+	}, [
+		isConnected,
+		chainId,
+		requiredChainId,
+		targetChain,
+		switchChainAsync,
+		transition,
+	]);
 
-	const dismiss = () => setStatus("idle");
+	const dismiss = useCallback(() => transition("idle"), [transition]);
 
 	return {
 		status,

--- a/src/hooks/use-ensure-correct-chain.ts
+++ b/src/hooks/use-ensure-correct-chain.ts
@@ -1,0 +1,92 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useAccount, useSwitchChain } from "wagmi";
+
+export type ChainStatus = "idle" | "correct" | "wrong-network" | "switching";
+
+export interface UseEnsureCorrectChainOptions {
+	/** The chain ID the app requires */
+	requiredChainId: number;
+	/** Called when status transitions (e.g. to open/close a modal) */
+	onStatusChange?: (status: ChainStatus, targetChainName?: string) => void;
+}
+
+export interface UseEnsureCorrectChainReturn {
+	/** Current chain-matching status */
+	status: ChainStatus;
+	/** Dismiss the wrong-network state (user chose to stay) */
+	dismiss: () => void;
+	/** Attempt to programmatically switch to the required chain */
+	switchToCorrectChain: () => Promise<void>;
+	/** The target chain object from the wagmi config, if found */
+	targetChain: ReturnType<typeof useSwitchChain>["chains"][number] | undefined;
+	/** Whether the wallet is connected */
+	isConnected: boolean;
+}
+
+export const useEnsureCorrectChain = ({
+	requiredChainId,
+	onStatusChange,
+}: UseEnsureCorrectChainOptions): UseEnsureCorrectChainReturn => {
+	const { chainId, isConnected } = useAccount();
+	const { switchChainAsync, chains } = useSwitchChain();
+	const [status, setStatus] = useState<ChainStatus>("idle");
+
+	const targetChain = chains.find((c) => c.id === requiredChainId);
+
+	const transition = useCallback(
+		(next: ChainStatus) => {
+			setStatus(next);
+			onStatusChange?.(next, targetChain?.name);
+		},
+		[onStatusChange, targetChain?.name],
+	);
+
+	useEffect(() => {
+		if (!isConnected || !chainId) {
+			transition("idle");
+			return;
+		}
+
+		transition(chainId === requiredChainId ? "correct" : "wrong-network");
+	}, [chainId, isConnected, requiredChainId, transition]);
+
+	const switchToCorrectChain = async () => {
+		if (!chainId) {
+			throw new Error(
+				"Wallet is not connected. Please connect your wallet first.",
+			);
+		}
+
+		if (chainId === requiredChainId) return;
+
+		if (!targetChain) {
+			throw new Error(
+				`Chain ID ${requiredChainId} is not configured in your wallet.`,
+			);
+		}
+
+		try {
+			transition("switching");
+			await switchChainAsync({ chainId: requiredChainId });
+			transition("correct");
+		} catch (error) {
+			console.error("Failed to switch network:", error);
+			transition("wrong-network");
+			throw new Error(
+				"Network switch failed. Please switch manually in your wallet.",
+			);
+		}
+	};
+
+	const dismiss = () => setStatus("idle");
+
+	return {
+		status,
+		dismiss,
+		switchToCorrectChain,
+		targetChain,
+		isConnected,
+	};
+};


### PR DESCRIPTION


### Summary

This PR introduces a new React hook, `useEnsureCorrectChain`, designed to simplify and standardize the process of ensuring a connected wallet is on the correct blockchain network.

The hook provides a clear status state machine and utilities for prompting network switches, significantly improving developer experience when building dApps that require specific chain interactions.

### ✨ What’s Included

#### 1. New Hook: `useEnsureCorrectChain.`

A dedicated hook that manages and enforces that the connected wallet is on a required chain.

#### 2. Unified Status Flow

The hook exposes a deterministic status state machine:

```
idle → wrong-network → switching → correct
```

This makes it easier to:

* Drive UI states (banners, modals, disabled buttons)
* Avoid ad-hoc network checks across components
* Centralize chain validation logic

#### 3. Programmatic Chain Switching

The hook provides:

* `switchToCorrectChain()` — Prompts the wallet to switch to the required network.
* `dismiss()` — Allows consumers to temporarily ignore the wrong-network state.

#### 4. Status Change Callback

An optional `onStatusChange` callback enables reacting to transitions (e.g., open/close modals automatically).

Example use cases:

* Auto-open a “Wrong Network” modal
* Track analytics events on network switch
* Trigger side effects when switching completes

#### 5. Documentation

Added comprehensive README documentation including:

* Basic usage example
* Callback integration example
* Full API reference

### 🎯 Why

Handling wallet network state is a common requirement across dApps. Previously, this logic had to be implemented manually in each feature or component.

This hook:

* Reduces duplicated logic
* Standardizes network enforcement patterns
* Improves UI consistency
* Simplifies onboarding for developers

### 🔄 Backwards Compatibility

No breaking changes.
This is a purely additive feature.
