### PR TITLE
fix: resolve Web3Auth social login failure caused by unreliable default RPCs

### DIFF
--- a/.changeset/fix-web3auth-social-login.md
+++ b/.changeset/fix-web3auth-social-login.md
@@ -1,0 +1,11 @@
+---
+"@everipedia/iq-login": patch
+---
+
+Fix Web3Auth social login by replacing unreliable viem default RPCs with PublicNode RPCs
+
+Viem's default RPCs (eth.merkle.io, polygon-rpc.com) fail for the RPC methods Web3Auth
+calls during provider setup after OAuth, causing social login to silently fail and return
+to the modal. This replaces them with reliable PublicNode RPCs for known chains and fixes
+the blockExplorerUrl bug where string indexing returned a single character instead of the
+full URL.

--- a/src/config/iq-login.config.ts
+++ b/src/config/iq-login.config.ts
@@ -35,6 +35,16 @@ export interface IqLoginConfig {
 	chains: [Chain, ...Chain[]];
 }
 
+// Reliable public RPCs for Web3Auth's provider setup.
+// Viem's default RPCs can be unreliable for eth_getBlockByNumber which
+// Web3Auth's TransactionFormatter.getEIP1559Compatibility calls during
+// provider setup after OAuth. e.g. eth.merkle.io times out on this call,
+// polygon-rpc.com returns no result. PublicNode handles these reliably.
+export const WEB3AUTH_RPC_TARGETS: Record<number, string> = {
+	1: "https://ethereum-rpc.publicnode.com", // Ethereum Mainnet
+	137: "https://polygon-bor-rpc.publicnode.com", // Polygon
+};
+
 export function createIqLoginConfig(
 	chains: [Chain, ...Chain[]] = [mainnet],
 ): IqLoginConfig {
@@ -85,16 +95,19 @@ function createWeb3AuthInstance(defaultChain: Chain) {
 	const chainConfig = {
 		chainNamespace: Web3AuthBase.CHAIN_NAMESPACES.EIP155,
 		chainId: `0x${defaultChain.id.toString(16)}`,
-		rpcTarget: defaultChain.rpcUrls.default.http[0],
+		rpcTarget:
+			WEB3AUTH_RPC_TARGETS[defaultChain.id] ??
+			defaultChain.rpcUrls.default.http[0],
 		displayName: defaultChain.name,
 		tickerName: defaultChain.nativeCurrency?.name,
 		ticker: defaultChain.nativeCurrency?.symbol,
-		blockExplorerUrl: defaultChain.blockExplorers?.default.url[0] as string,
+		blockExplorerUrl: defaultChain.blockExplorers?.default.url as string,
 	};
 
-	// Initialize Web3Auth with only the default chain
+	// Initialize Web3Auth with the default chain
 	return new Web3AuthModal.Web3Auth({
 		clientId: WEB_3_AUTH_CLIENT_ID,
+		chainConfig,
 		privateKeyProvider: new Web3AuthEthereumProvider.EthereumPrivateKeyProvider(
 			{
 				config: { chainConfig },

--- a/src/config/iq-login.config.ts
+++ b/src/config/iq-login.config.ts
@@ -101,7 +101,7 @@ function createWeb3AuthInstance(defaultChain: Chain) {
 		displayName: defaultChain.name,
 		tickerName: defaultChain.nativeCurrency?.name,
 		ticker: defaultChain.nativeCurrency?.symbol,
-		blockExplorerUrl: defaultChain.blockExplorers?.default.url as string,
+		blockExplorerUrl: defaultChain.blockExplorers?.default.url,
 	};
 
 	// Initialize Web3Auth with the default chain

--- a/src/config/iq-login.config.ts
+++ b/src/config/iq-login.config.ts
@@ -35,14 +35,9 @@ export interface IqLoginConfig {
 	chains: [Chain, ...Chain[]];
 }
 
-// Reliable public RPCs for Web3Auth's provider setup.
-// Viem's default RPCs can be unreliable for eth_getBlockByNumber which
-// Web3Auth's TransactionFormatter.getEIP1559Compatibility calls during
-// provider setup after OAuth. e.g. eth.merkle.io times out on this call,
-// polygon-rpc.com returns no result. PublicNode handles these reliably.
 export const WEB3AUTH_RPC_TARGETS: Record<number, string> = {
-	1: "https://ethereum-rpc.publicnode.com", // Ethereum Mainnet
-	137: "https://polygon-bor-rpc.publicnode.com", // Polygon
+	1: "https://ethereum-rpc.publicnode.com",
+	137: "https://polygon-bor-rpc.publicnode.com",
 };
 
 export function createIqLoginConfig(

--- a/src/hooks/use-web-3-auth.tsx
+++ b/src/hooks/use-web-3-auth.tsx
@@ -51,7 +51,7 @@ export function Web3AuthProvider({
 							displayName: chain.name,
 							tickerName: chain.nativeCurrency?.name,
 							ticker: chain.nativeCurrency?.symbol,
-							blockExplorerUrl: chain.blockExplorers?.default.url as string,
+							blockExplorerUrl: chain.blockExplorers?.default.url,
 						};
 
 						await web3AuthInstance.addChain(chainConfig);

--- a/src/hooks/use-web-3-auth.tsx
+++ b/src/hooks/use-web-3-auth.tsx
@@ -3,6 +3,7 @@ import { CHAIN_NAMESPACES } from "@web3auth/base";
 import type { Web3Auth } from "@web3auth/modal";
 import { createContext, useContext, useEffect, useState } from "react";
 import type { Chain } from "viem/chains";
+import { WEB3AUTH_RPC_TARGETS } from "../config/iq-login.config";
 
 export interface Web3AuthContextType {
 	web3Auth: Web3Auth | null;
@@ -45,11 +46,12 @@ export function Web3AuthProvider({
 						const chainConfig = {
 							chainNamespace: CHAIN_NAMESPACES.EIP155,
 							chainId: `0x${chain.id.toString(16)}`,
-							rpcTarget: chain.rpcUrls.default.http[0],
+							rpcTarget:
+								WEB3AUTH_RPC_TARGETS[chain.id] ?? chain.rpcUrls.default.http[0],
 							displayName: chain.name,
 							tickerName: chain.nativeCurrency?.name,
 							ticker: chain.nativeCurrency?.symbol,
-							blockExplorerUrl: chain.blockExplorers?.default.url[0] as string,
+							blockExplorerUrl: chain.blockExplorers?.default.url as string,
 						};
 
 						await web3AuthInstance.addChain(chainConfig);


### PR DESCRIPTION
## Summary
- Replace viem's default RPC endpoints (`eth.merkle.io`, `polygon-rpc.com`) with reliable PublicNode RPCs for Ethereum and Polygon — these defaults fail for `eth_getBlockByNumber` which Web3Auth's `TransactionFormatter` calls during provider setup after OAuth, causing social login to silently fail
- Fix `blockExplorerUrl` bug where `.url[0]` string indexing returned `"h"` instead of the full URL
- Pass `chainConfig` to the `Web3Auth` constructor as required by the SDK
- Apply the same PublicNode RPC override to `addChain` calls in `use-web-3-auth.tsx` for multi-chain consistency

## Test plan
- [x] RPC connectivity tests confirm PublicNode endpoints respond correctly to `eth_chainId` and `eth_getBlockByNumber`
- [x] Build passes with no type errors
- [x] Manual test: Google social login works on iq-wiki with linked local package

closes https://github.com/EveripediaNetwork/issues/issues/4867