### PR TITLE
Feat/customizable login UI

### DIFF
--- a/.changeset/customizable-login-ui.md
+++ b/.changeset/customizable-login-ui.md
@@ -1,0 +1,5 @@
+---
+"@everipedia/iq-login": minor
+---
+
+Add UI customization props to `Login`: `variant` ("page" | "card"), per-slot `classNames` overrides, `connectorMeta` label/description/icon overrides, `header`/`footer` slots, and a `renderConnector` render prop. Also adds a headless `useLoginFlow()` hook for building fully custom login UIs without the built-in markup. Rendering with no new props is unchanged.

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ coverage
 # API keys and secrets
 .env
 
+*.test.ts
+
 # Dependency directory
 node_modules
 bower_components

--- a/README.md
+++ b/README.md
@@ -224,6 +224,108 @@ const { status, switchToCorrectChain } = useEnsureCorrectChain({
 
 The package uses Tailwind CSS and Shadcn UI Theme. Visit https://ui.shadcn.com/themes for theme customization.
 
+## 🧩 Customizing the UI
+
+All customization props are optional — with none, `Login` renders the default design.
+
+```tsx
+import { Login } from "@everipedia/iq-login/client";
+
+<Login
+	// Render only the card (no page wrapper/title) so you can place it in your own modal
+	variant="card"
+	// Replace the default icon + heading block
+	header={<MyBannerHeader />}
+	// Rendered below the wallet list (connect view only)
+	footer={<a href="/claim">← just claim a handle instead (no wallet)</a>}
+	// Relabel / re-icon the built-in connectors (keys: Injected, WalletConnect, Web3Auth)
+	connectorMeta={{
+		Injected: { label: "METAMASK", description: "browser extension" },
+		WalletConnect: { label: "WALLETCONNECT", description: "scan with any wallet" },
+		Web3Auth: { label: "SOCIAL LOGIN", description: "google, x, discord" },
+	}}
+	// Override classes per named slot (merged over defaults; your classes win conflicts)
+	classNames={{
+		connectorButton: "border-slate-700 bg-slate-950 hover:bg-slate-900",
+		connectorLabel: "font-bold uppercase tracking-wider",
+		connectorDescription: "font-mono",
+	}}
+/>
+```
+
+Available slots: `root`, `container`, `title`, `description`, `card`, `cardBody`, `headerIcon`, `headerTitle`, `connectorList`, `connectorButton`, `connectorIcon`, `connectorLabel`, `connectorDescription`, `connectorError`, `connectorArrow`, `connectedTitle`, `logoutButton`, `addressBox`, `addressText`, `divider`, `dividerLabel`, `verificationCard`, `verificationIcon`, `verificationTitle`, `verificationDescription`, `signButton`, `statusText`.
+
+For full control of a wallet row, pass `renderConnector`:
+
+```tsx
+<Login
+	renderConnector={({ meta, connect, isPending }) => (
+		<button type="button" onClick={connect} disabled={isPending}>
+			<meta.icon className="size-8" />
+			{meta.label}
+		</button>
+	)}
+/>
+```
+
+## 🪝 Fully Custom UI (Headless)
+
+If restyling `Login` isn't enough — you want to own the entire markup — use `useLoginFlow()` and keep none of the built-in UI. The default `Login` component keeps working unchanged for projects that don't customize.
+
+```tsx
+"use client";
+import { useLoginFlow } from "@everipedia/iq-login/client";
+
+function MyLogin() {
+	const {
+		connectors,      // [{ connector, meta: { label, description, icon }, connect, isPending, error }]
+		isConnected,
+		address,
+		token,
+		signToken,       // trigger the sign-in signature
+		signing,         // signature in progress
+		signError,
+		logout,
+		disableAuth,
+	} = useLoginFlow({
+		connectorMeta: {
+			Injected: { label: "MetaMask", description: "browser extension" },
+		},
+	});
+
+	if (!isConnected) {
+		return (
+			<ul>
+				{connectors.map(({ connector, meta, connect, isPending }) => (
+					<li key={connector.uid}>
+						<button type="button" onClick={connect} disabled={isPending}>
+							<meta.icon className="size-8" />
+							{meta.label} — {meta.description}
+						</button>
+					</li>
+				))}
+			</ul>
+		);
+	}
+
+	if (!token && !disableAuth) {
+		return (
+			<button type="button" onClick={signToken} disabled={signing}>
+				{signing ? "Waiting for signature..." : signError ? "Retry" : "Verify identity"}
+			</button>
+		);
+	}
+
+	return (
+		<p>
+			Signed in as {address} <button type="button" onClick={logout}>Log out</button>
+		</p>
+	);
+}
+```
+
+Must be rendered inside `IqLoginProvider`.
+
 ## 📝 Usage on Pages Router
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -259,10 +259,10 @@ For full control of a wallet row, pass `renderConnector`:
 
 ```tsx
 <Login
-	renderConnector={({ meta, connect, isPending }) => (
+	renderConnector={({ meta, connect, isPending, isConnecting }) => (
 		<button type="button" onClick={connect} disabled={isPending}>
 			<meta.icon className="size-8" />
-			{meta.label}
+			{isConnecting ? "Connecting..." : meta.label}
 		</button>
 	)}
 />
@@ -278,7 +278,7 @@ import { useLoginFlow } from "@everipedia/iq-login/client";
 
 function MyLogin() {
 	const {
-		connectors,      // [{ connector, meta: { label, description, icon }, connect, isPending, error }]
+		connectors,      // [{ connector, meta: { label, description, icon }, connect, isPending, isConnecting, error }]
 		isConnected,
 		address,
 		token,
@@ -296,11 +296,11 @@ function MyLogin() {
 	if (!isConnected) {
 		return (
 			<ul>
-				{connectors.map(({ connector, meta, connect, isPending }) => (
+				{connectors.map(({ connector, meta, connect, isPending, isConnecting }) => (
 					<li key={connector.uid}>
 						<button type="button" onClick={connect} disabled={isPending}>
 							<meta.icon className="size-8" />
-							{meta.label} — {meta.description}
+							{isConnecting ? "Connecting..." : `${meta.label} — ${meta.description}`}
 						</button>
 					</li>
 				))}

--- a/package.json
+++ b/package.json
@@ -41,8 +41,10 @@
 		"@web3auth/wallet-services-plugin": "^9.7.0",
 		"@web3auth/web3auth-wagmi-connector": "^7.0.0",
 		"boring-avatars": "^1.11.2",
+		"clsx": "^2.1.1",
 		"cookies-next": "^5.1.0",
 		"lucide-react": "^0.488.0",
+		"tailwind-merge": "^3.6.0",
 		"vitest": "^3.1.1",
 		"zod": "^3.24.3",
 		"zustand": "^5.0.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       boring-avatars:
         specifier: ^1.11.2
         version: 1.11.2
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       cookies-next:
         specifier: ^5.1.0
         version: 5.1.0(next@15.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
@@ -47,6 +50,9 @@ importers:
       react-dom:
         specifier: 19.1.0
         version: 19.1.0(react@19.1.0)
+      tailwind-merge:
+        specifier: ^3.6.0
+        version: 3.6.0
       vitest:
         specifier: ^3.1.1
         version: 3.1.1(@types/debug@4.1.12)(@types/node@22.14.1)(jiti@2.4.2)(terser@5.37.0)(yaml@2.7.0)
@@ -1468,6 +1474,10 @@ packages:
     resolution: {integrity: sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==}
     engines: {node: '>=6'}
 
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -2659,6 +2669,9 @@ packages:
     resolution: {integrity: sha512-7JpaAoX2NGyoFlI9NBh66BQXGONc+uE+MRS5i2iOBKuS4e+ccgMDjATgZldkah+33DakBxDHiss9kvUcGAO8UQ==}
     engines: {node: '>=14.0.0'}
 
+  tailwind-merge@3.6.0:
+    resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
+
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
@@ -2880,6 +2893,7 @@ packages:
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   valtio@1.11.2:
@@ -5095,6 +5109,8 @@ snapshots:
 
   clsx@1.2.1: {}
 
+  clsx@2.1.1: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -5386,7 +5402,7 @@ snapshots:
 
   extension-port-stream@3.0.0:
     dependencies:
-      readable-stream: 3.6.2
+      readable-stream: 4.7.0
       webextension-polyfill: 0.10.0
 
   external-editor@3.1.0:
@@ -5869,7 +5885,7 @@ snapshots:
     dependencies:
       '@adraffy/ens-normalize': 1.11.0
       '@noble/curves': 1.8.1
-      '@noble/hashes': 1.7.1
+      '@noble/hashes': 1.7.2
       '@scure/bip32': 1.6.2
       '@scure/bip39': 1.5.4
       abitype: 1.0.8(typescript@5.8.3)(zod@3.24.3)
@@ -6321,6 +6337,8 @@ snapshots:
       ts-interface-checker: 0.1.13
 
   superstruct@1.0.4: {}
+
+  tailwind-merge@3.6.0: {}
 
   term-size@2.2.1: {}
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -25,7 +25,6 @@ export { useAuth } from "./hooks/use-auth";
 export { useWeb3Auth } from "./hooks/use-web-3-auth";
 export {
 	useLoginFlow,
-	type LoginFlowConnector,
 	type UseLoginFlowOptions,
 	type UseLoginFlowReturn,
 } from "./hooks/use-login-flow";

--- a/src/client.ts
+++ b/src/client.ts
@@ -5,13 +5,30 @@
 // ===============
 export { CustomAvatar } from "./components/custom-avatar";
 export { IqLoginProvider } from "./components/iq-login-provider";
-export { Login } from "./components/login-element";
+export {
+	Login,
+	type ConnectorRow,
+	type LoginProps,
+	type LoginVariant,
+} from "./components/login-element";
+
+export type {
+	ConnectorMeta,
+	ResolvedConnectorMeta,
+} from "./components/connector-meta";
+export type { LoginSlot } from "./components/login-slots";
 
 // ===============
 // Hooks
 // ===============
 export { useAuth } from "./hooks/use-auth";
 export { useWeb3Auth } from "./hooks/use-web-3-auth";
+export {
+	useLoginFlow,
+	type LoginFlowConnector,
+	type UseLoginFlowOptions,
+	type UseLoginFlowReturn,
+} from "./hooks/use-login-flow";
 export {
 	useEnsureCorrectChain,
 	type ChainStatus,

--- a/src/components/connector-meta.ts
+++ b/src/components/connector-meta.ts
@@ -1,0 +1,35 @@
+import { Wallet } from "lucide-react";
+import type React from "react";
+import { Injected } from "../icons/injected";
+import { Social } from "../icons/social";
+import { WalletConnect } from "../icons/wallet-connect";
+
+export interface ConnectorMeta {
+	label?: string;
+	description?: string;
+	icon?: React.ComponentType<{ className?: string }>;
+}
+
+export type ResolvedConnectorMeta = Required<ConnectorMeta>;
+
+const DEFAULT_CONNECTOR_META: Record<string, ConnectorMeta> = {
+	Web3Auth: { label: "Social Login", icon: Social },
+	Injected: { label: "Browser Wallet", icon: Injected },
+	WalletConnect: { label: "Wallet Connect", icon: WalletConnect },
+};
+
+export function resolveConnectorMeta(
+	name: string,
+	overrides?: Record<string, ConnectorMeta>,
+): ResolvedConnectorMeta {
+	const base = DEFAULT_CONNECTOR_META[name];
+	const override = overrides?.[name];
+	return {
+		label: override?.label ?? base?.label ?? name,
+		description:
+			override?.description ??
+			base?.description ??
+			`Connect using your ${name} wallet`,
+		icon: override?.icon ?? base?.icon ?? Wallet,
+	};
+}

--- a/src/components/login-element.tsx
+++ b/src/components/login-element.tsx
@@ -157,6 +157,8 @@ const WalletConnectView = ({
 							meta={meta}
 							onClick={() => connect({ connector })}
 							slot={slot}
+							isPending={isPending}
+							error={error}
 						/>
 					);
 				})}
@@ -166,17 +168,19 @@ const WalletConnectView = ({
 	);
 };
 
-const ConnectorButton = ({
+export const ConnectorButton = ({
 	meta,
 	onClick,
 	slot,
+	isPending,
+	error,
 }: {
 	meta: ResolvedConnectorMeta;
 	onClick: () => void;
 	slot: SlotFn;
+	isPending: boolean;
+	error: Error | null;
 }) => {
-	const { isPending, error } = useConnect();
-
 	const ConnectorIcon = meta.icon;
 
 	return (

--- a/src/components/login-element.tsx
+++ b/src/components/login-element.tsx
@@ -26,7 +26,13 @@ export interface ConnectorRow {
 	connector: Connector;
 	meta: ResolvedConnectorMeta;
 	connect: () => void;
+	/**
+	 * True while ANY connect attempt is in flight (wagmi mutation state) —
+	 * every row reports it, e.g. to disable all buttons during a connect.
+	 * Use `isConnecting` for the row that owns the attempt.
+	 */
 	isPending: boolean;
+	/** True only on the connector the current connect attempt targets. */
 	isConnecting: boolean;
 	error: Error | null;
 }
@@ -270,7 +276,7 @@ const ConnectedWalletView = ({
 
 			{disableAuth ? (
 				<div className="w-full grid place-items-center">
-					<div className={`${slot("statusText")} text-success text-green-500`}>
+					<div className={slot("statusText", "text-green-500")}>
 						<CheckCircle className="h-4 w-4" />
 						<p className="font-medium text-sm">Successfully signed in!</p>
 					</div>
@@ -370,7 +376,7 @@ export const SignTokenButton = ({
 			);
 		}
 		return (
-			<div className={`${slot("statusText")} text-success text-green-500`}>
+			<div className={slot("statusText", "text-green-500")}>
 				<CheckCircle className="h-4 w-4" />
 				<p className="font-medium text-sm">Successfully signed in!</p>
 			</div>

--- a/src/components/login-element.tsx
+++ b/src/components/login-element.tsx
@@ -7,13 +7,46 @@ import {
 	Wallet,
 	XCircle,
 } from "lucide-react";
-import { useEffect } from "react";
-import { useAccount, useConnect } from "wagmi";
+import type React from "react";
+import { Fragment, useEffect } from "react";
+import { type Connector, useAccount, useConnect } from "wagmi";
 import { useAuth } from "../client";
 import { useProject } from "../hooks/use-project";
-import { Injected } from "../icons/injected";
-import { Social } from "../icons/social";
-import { WalletConnect } from "../icons/wallet-connect";
+import { cn } from "../lib/cn";
+import {
+	type ConnectorMeta,
+	type ResolvedConnectorMeta,
+	resolveConnectorMeta,
+} from "./connector-meta";
+import { defaultClassNames, type LoginSlot } from "./login-slots";
+
+export type LoginVariant = "page" | "card";
+
+export interface ConnectorRow {
+	connector: Connector;
+	meta: ResolvedConnectorMeta;
+	connect: () => void;
+	isPending: boolean;
+	error: Error | null;
+}
+
+export interface LoginProps {
+	title?: string;
+	description?: string;
+	connectText?: string;
+	signTokenText?: string;
+	handleRedirect?: () => void;
+	variant?: LoginVariant;
+	classNames?: Partial<Record<LoginSlot, string>>;
+	connectorMeta?: Record<string, ConnectorMeta>;
+	header?: React.ReactNode;
+	footer?: React.ReactNode;
+	renderConnector?: (row: ConnectorRow) => React.ReactNode;
+}
+
+type SlotFn = (name: LoginSlot, extra?: string) => string;
+
+const defaultSlot: SlotFn = (name, extra) => cn(defaultClassNames[name], extra);
 
 export const Login = ({
 	title = "Welcome Back",
@@ -21,123 +54,157 @@ export const Login = ({
 	connectText = "Connect Wallet",
 	signTokenText = "Verify Identity",
 	handleRedirect,
-}: {
-	title?: string;
-	description?: string;
-	connectText?: string;
-	signTokenText?: string;
-	handleRedirect?: () => void;
-}) => {
+	variant = "page",
+	classNames,
+	connectorMeta,
+	header,
+	footer,
+	renderConnector,
+}: LoginProps) => {
 	const { isConnected } = useAccount();
 	const { disableAuth } = useProject();
 
+	const slot: SlotFn = (name, extra) =>
+		cn(defaultClassNames[name], extra, classNames?.[name]);
+
+	const card = (
+		<div className={slot("card")}>
+			{isConnected ? (
+				<ConnectedWalletView
+					signTokenText={signTokenText}
+					handleRedirect={handleRedirect}
+					disableAuth={disableAuth}
+					slot={slot}
+				/>
+			) : (
+				<WalletConnectView
+					connectText={connectText}
+					slot={slot}
+					header={header}
+					footer={footer}
+					connectorMeta={connectorMeta}
+					renderConnector={renderConnector}
+				/>
+			)}
+		</div>
+	);
+
+	if (variant === "card") {
+		return card;
+	}
+
 	return (
-		<div className="min-h-[60vh] w-full flex items-center justify-center px-4 py-8">
-			<div className="relative w-full max-w-md">
+		<div className={slot("root")}>
+			<div className={slot("container")}>
 				<div className="space-y-8 text-center">
 					<div className="space-y-2">
-						<h1 className="text-2xl font-bold tracking-tighter sm:text-3xl md:text-4xl">
-							{title}
-						</h1>
-						<p className="mx-auto max-w-[500px] text-muted-foreground text-sm md:text-base">
-							{description}
-						</p>
+						<h1 className={slot("title")}>{title}</h1>
+						<p className={slot("description")}>{description}</p>
 					</div>
-					<div className="mx-auto">
-						<div className="overflow-hidden rounded-lg border bg-card shadow">
-							{isConnected ? (
-								<ConnectedWalletView
-									signTokenText={signTokenText}
-									handleRedirect={handleRedirect}
-									disableAuth={disableAuth}
-								/>
-							) : (
-								<WalletConnectView connectText={connectText} />
-							)}
-						</div>
-					</div>
+					<div className="mx-auto">{card}</div>
 				</div>
 			</div>
 		</div>
 	);
 };
 
-const WalletConnectView = ({ connectText }: { connectText: string }) => {
-	const { connect, connectors } = useConnect();
+const WalletConnectView = ({
+	connectText,
+	slot,
+	header,
+	footer,
+	connectorMeta,
+	renderConnector,
+}: {
+	connectText: string;
+	slot: SlotFn;
+	header?: React.ReactNode;
+	footer?: React.ReactNode;
+	connectorMeta?: Record<string, ConnectorMeta>;
+	renderConnector?: (row: ConnectorRow) => React.ReactNode;
+}) => {
+	const { connect, connectors, isPending, error } = useConnect();
 
 	return (
-		<div className="p-4">
-			<div className="flex items-center justify-center w-8 h-8 mx-auto rounded-lg bg-primary/10">
-				<Wallet className="w-4 h-4 text-primary" />
+		<div className={slot("cardBody")}>
+			{header ?? (
+				<div>
+					<div className={slot("headerIcon")}>
+						<Wallet className="w-4 h-4 text-primary" />
+					</div>
+					<h2 className={slot("headerTitle")}>{connectText}</h2>
+				</div>
+			)}
+			<div className={slot("connectorList")}>
+				{connectors.map((connector) => {
+					const meta = resolveConnectorMeta(connector.name, connectorMeta);
+					if (renderConnector) {
+						return (
+							<Fragment key={connector.uid}>
+								{renderConnector({
+									connector,
+									meta,
+									connect: () => connect({ connector }),
+									isPending,
+									error,
+								})}
+							</Fragment>
+						);
+					}
+					return (
+						<ConnectorButton
+							key={connector.uid}
+							meta={meta}
+							onClick={() => connect({ connector })}
+							slot={slot}
+						/>
+					);
+				})}
 			</div>
-			<h2 className="mt-3 mb-3 text-lg font-semibold">{connectText}</h2>
-			<div className="grid gap-3">
-				{connectors.map((connector) => (
-					<ConnectorButton
-						key={connector.uid}
-						name={connector.name}
-						onClick={() => connect({ connector })}
-					/>
-				))}
-			</div>
+			{footer}
 		</div>
 	);
 };
 
 const ConnectorButton = ({
-	name,
+	meta,
 	onClick,
+	slot,
 }: {
-	name: string;
+	meta: ResolvedConnectorMeta;
 	onClick: () => void;
+	slot: SlotFn;
 }) => {
 	const { isPending, error } = useConnect();
 
-	const connectorConfig = {
-		Web3Auth: {
-			label: "Social Login",
-			icon: Social,
-		},
-		Injected: {
-			label: "Browser Wallet",
-			icon: Injected,
-		},
-		WalletConnect: {
-			label: "Wallet Connect",
-			icon: WalletConnect,
-		},
-	};
-
-	const config = connectorConfig[name as keyof typeof connectorConfig] || {
-		label: name,
-		icon: Wallet,
-	};
-
-	const ConnectorIcon = config.icon;
+	const ConnectorIcon = meta.icon;
 
 	return (
 		<button
 			type="button"
 			onClick={onClick}
 			disabled={isPending}
-			className="group relative flex items-center justify-between rounded-lg border bg-card p-4 text-left transition-colors hover:bg-accent disabled:opacity-50"
+			className={slot("connectorButton")}
 		>
 			<div className="flex items-center gap-3">
-				<ConnectorIcon className="size-8 text-primary" />
+				<ConnectorIcon className={slot("connectorIcon")} />
 				<div>
-					<p className="font-medium text-sm">{config.label}</p>
-					<p className="text-xs text-muted-foreground">
-						{isPending ? "Connecting..." : `Connect using your ${name} wallet`}
+					<p className={slot("connectorLabel")}>{meta.label}</p>
+					<p className={slot("connectorDescription")}>
+						{isPending ? "Connecting..." : meta.description}
 					</p>
-					{error && (
-						<p className="text-xs text-destructive mt-1">{error.message}</p>
-					)}
+					{error && <p className={slot("connectorError")}>{error.message}</p>}
 				</div>
 			</div>
 			{isPending ? (
-				<Loader2 className="w-4 h-4 animate-spin text-muted-foreground" />
+				<Loader2 className={slot("connectorArrow", "animate-spin")} />
 			) : (
-				<ArrowRight className="w-4 h-4 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
+				<ArrowRight
+					className={slot(
+						"connectorArrow",
+						"transition-transform group-hover:translate-x-0.5",
+					)}
+				/>
 			)}
 		</button>
 	);
@@ -147,10 +214,12 @@ const ConnectedWalletView = ({
 	signTokenText,
 	handleRedirect,
 	disableAuth,
+	slot,
 }: {
 	signTokenText: string;
 	handleRedirect?: () => void;
 	disableAuth?: boolean;
+	slot: SlotFn;
 }) => {
 	const { address } = useAccount();
 	const { logout } = useAuth();
@@ -163,31 +232,31 @@ const ConnectedWalletView = ({
 	}, [disableAuth, handleRedirect]);
 
 	return (
-		<div className="p-4">
+		<div className={slot("cardBody")}>
 			<div className="flex items-center justify-between mb-4">
 				<div className="flex items-center gap-2">
 					<div className="flex items-center justify-center w-8 h-8 rounded-lg bg-primary/10">
 						<Wallet className="w-3 h-3 text-primary" />
 					</div>
-					<p className="font-medium text-sm">Connected Wallet</p>
+					<p className={slot("connectedTitle")}>Connected Wallet</p>
 				</div>
 				<button
 					type="button"
 					onClick={logout}
-					className="p-1.5 rounded-full hover:bg-destructive/10 text-destructive transition-colors"
+					className={slot("logoutButton")}
 					title="Disconnect wallet"
 				>
 					<LogOut className="w-4 h-4" />
 				</button>
 			</div>
 
-			<div className="rounded-lg bg-muted/50 border p-3 mb-4">
-				<p className="font-mono text-xs break-all">{address}</p>
+			<div className={slot("addressBox")}>
+				<p className={slot("addressText")}>{address}</p>
 			</div>
 
 			{disableAuth ? (
 				<div className="w-full grid place-items-center">
-					<div className="flex items-center gap-2 text-success py-1.5 text-green-500">
+					<div className={`${slot("statusText")} text-success text-green-500`}>
 						<CheckCircle className="h-4 w-4" />
 						<p className="font-medium text-sm">Successfully signed in!</p>
 					</div>
@@ -196,6 +265,7 @@ const ConnectedWalletView = ({
 				<VerificationSection
 					signTokenText={signTokenText}
 					handleRedirect={handleRedirect ?? (() => {})}
+					slot={slot}
 				/>
 			)}
 		</div>
@@ -205,33 +275,35 @@ const ConnectedWalletView = ({
 const VerificationSection = ({
 	signTokenText,
 	handleRedirect,
+	slot,
 }: {
 	signTokenText: string;
 	handleRedirect: () => void;
+	slot: SlotFn;
 }) => (
 	<div className="space-y-3">
-		<div className="relative">
+		<div className={slot("divider")}>
 			<div className="absolute inset-0 flex items-center">
 				<div className="w-full border-t" />
 			</div>
 			<div className="relative flex justify-center text-xs uppercase">
-				<span className="bg-card px-2 text-muted-foreground">Next Step</span>
+				<span className={slot("dividerLabel")}>Next Step</span>
 			</div>
 		</div>
 
-		<div className="rounded-lg border p-4 text-center">
+		<div className={slot("verificationCard")}>
 			<div className="flex flex-col items-center gap-3">
-				<div className="flex items-center justify-center w-10 h-10 rounded-lg bg-primary/10">
+				<div className={slot("verificationIcon")}>
 					<Shield className="w-4 h-4 text-primary" />
 				</div>
 				<div className="space-y-1">
-					<h3 className="font-medium text-base">{signTokenText}</h3>
-					<p className="text-xs text-muted-foreground">
+					<h3 className={slot("verificationTitle")}>{signTokenText}</h3>
+					<p className={slot("verificationDescription")}>
 						Sign a message to verify your wallet ownership
 					</p>
 				</div>
 				<div className="w-full flex justify-center">
-					<SignTokenButton handleRedirect={handleRedirect} />
+					<SignTokenButton handleRedirect={handleRedirect} slot={slot} />
 				</div>
 			</div>
 		</div>
@@ -241,9 +313,11 @@ const VerificationSection = ({
 export const SignTokenButton = ({
 	handleRedirect,
 	handleTokenPass,
+	slot = defaultSlot,
 }: {
 	handleRedirect: () => void;
 	handleTokenPass?: (token: string) => Promise<void>;
+	slot?: SlotFn;
 }) => {
 	const { isConnected } = useAccount();
 	const { token, signToken, loading, error } = useAuth();
@@ -267,7 +341,7 @@ export const SignTokenButton = ({
 	const StatusDisplay = () => {
 		if (error) {
 			return (
-				<div className="flex items-center gap-2 text-destructive py-1.5">
+				<div className={slot("statusText", "text-destructive")}>
 					<XCircle className="h-4 w-4" />
 					<p className="font-medium text-sm">Failed to sign. Try again</p>
 				</div>
@@ -275,14 +349,14 @@ export const SignTokenButton = ({
 		}
 		if (loading) {
 			return (
-				<div className="flex items-center gap-2 text-primary py-1.5">
+				<div className={slot("statusText", "text-primary")}>
 					<Loader2 className="h-4 w-4 animate-spin" />
 					<p className="font-medium text-sm">Waiting for signature...</p>
 				</div>
 			);
 		}
 		return (
-			<div className="flex items-center gap-2 text-success py-1.5 text-green-500">
+			<div className={`${slot("statusText")} text-success text-green-500`}>
 				<CheckCircle className="h-4 w-4" />
 				<p className="font-medium text-sm">Successfully signed in!</p>
 			</div>
@@ -302,7 +376,7 @@ export const SignTokenButton = ({
 			type="button"
 			onClick={signToken}
 			disabled={!isConnected}
-			className="inline-flex w-full max-w-xs items-center justify-center gap-2 rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 px-4 py-2 text-sm font-medium transition-all duration-200 hover:scale-[1.02] active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none disabled:cursor-not-allowed"
+			className={slot("signButton")}
 		>
 			<Shield className="h-4 w-4" />
 			Sign Token

--- a/src/components/login-element.tsx
+++ b/src/components/login-element.tsx
@@ -27,6 +27,7 @@ export interface ConnectorRow {
 	meta: ResolvedConnectorMeta;
 	connect: () => void;
 	isPending: boolean;
+	isConnecting: boolean;
 	error: Error | null;
 }
 
@@ -123,7 +124,11 @@ const WalletConnectView = ({
 	connectorMeta?: Record<string, ConnectorMeta>;
 	renderConnector?: (row: ConnectorRow) => React.ReactNode;
 }) => {
-	const { connect, connectors, isPending, error } = useConnect();
+	const { connect, connectors, isPending, error, variables } = useConnect();
+	const pendingConnector =
+		isPending && typeof variables?.connector === "object"
+			? variables.connector
+			: undefined;
 
 	return (
 		<div className={slot("cardBody")}>
@@ -138,6 +143,7 @@ const WalletConnectView = ({
 			<div className={slot("connectorList")}>
 				{connectors.map((connector) => {
 					const meta = resolveConnectorMeta(connector.name, connectorMeta);
+					const isConnecting = pendingConnector?.uid === connector.uid;
 					if (renderConnector) {
 						return (
 							<Fragment key={connector.uid}>
@@ -146,6 +152,7 @@ const WalletConnectView = ({
 									meta,
 									connect: () => connect({ connector }),
 									isPending,
+									isConnecting,
 									error,
 								})}
 							</Fragment>
@@ -158,6 +165,7 @@ const WalletConnectView = ({
 							onClick={() => connect({ connector })}
 							slot={slot}
 							isPending={isPending}
+							isConnecting={isConnecting}
 							error={error}
 						/>
 					);
@@ -173,12 +181,14 @@ export const ConnectorButton = ({
 	onClick,
 	slot,
 	isPending,
+	isConnecting,
 	error,
 }: {
 	meta: ResolvedConnectorMeta;
 	onClick: () => void;
 	slot: SlotFn;
 	isPending: boolean;
+	isConnecting: boolean;
 	error: Error | null;
 }) => {
 	const ConnectorIcon = meta.icon;
@@ -195,12 +205,12 @@ export const ConnectorButton = ({
 				<div>
 					<p className={slot("connectorLabel")}>{meta.label}</p>
 					<p className={slot("connectorDescription")}>
-						{isPending ? "Connecting..." : meta.description}
+						{isConnecting ? "Connecting..." : meta.description}
 					</p>
 					{error && <p className={slot("connectorError")}>{error.message}</p>}
 				</div>
 			</div>
-			{isPending ? (
+			{isConnecting ? (
 				<Loader2 className={slot("connectorArrow", "animate-spin")} />
 			) : (
 				<ArrowRight

--- a/src/components/login-slots.ts
+++ b/src/components/login-slots.ts
@@ -1,0 +1,37 @@
+export const defaultClassNames = {
+	root: "min-h-[60vh] w-full flex items-center justify-center px-4 py-8",
+	container: "relative w-full max-w-md",
+	title: "text-2xl font-bold tracking-tighter sm:text-3xl md:text-4xl",
+	description:
+		"mx-auto max-w-[500px] text-muted-foreground text-sm md:text-base",
+	card: "overflow-hidden rounded-lg border bg-card shadow",
+	cardBody: "p-4",
+	headerIcon:
+		"flex items-center justify-center w-8 h-8 mx-auto rounded-lg bg-primary/10",
+	headerTitle: "mt-3 mb-3 text-lg font-semibold",
+	connectorList: "grid gap-3",
+	connectorButton:
+		"group relative flex items-center justify-between rounded-lg border bg-card p-4 text-left transition-colors hover:bg-accent disabled:opacity-50",
+	connectorIcon: "size-8 text-primary",
+	connectorLabel: "font-medium text-sm",
+	connectorDescription: "text-xs text-muted-foreground",
+	connectorError: "text-xs text-destructive mt-1",
+	connectorArrow: "w-4 h-4 text-muted-foreground",
+	connectedTitle: "font-medium text-sm",
+	logoutButton:
+		"p-1.5 rounded-full hover:bg-destructive/10 text-destructive transition-colors",
+	addressBox: "rounded-lg bg-muted/50 border p-3 mb-4",
+	addressText: "font-mono text-xs break-all",
+	divider: "relative",
+	dividerLabel: "bg-card px-2 text-muted-foreground",
+	verificationCard: "rounded-lg border p-4 text-center",
+	verificationIcon:
+		"flex items-center justify-center w-10 h-10 rounded-lg bg-primary/10",
+	verificationTitle: "font-medium text-base",
+	verificationDescription: "text-xs text-muted-foreground",
+	signButton:
+		"inline-flex w-full max-w-xs items-center justify-center gap-2 rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 px-4 py-2 text-sm font-medium transition-all duration-200 hover:scale-[1.02] active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none disabled:cursor-not-allowed",
+	statusText: "flex items-center gap-2 py-1.5",
+} as const satisfies Record<string, string>;
+
+export type LoginSlot = keyof typeof defaultClassNames;

--- a/src/hooks/use-login-flow.ts
+++ b/src/hooks/use-login-flow.ts
@@ -13,6 +13,7 @@ export interface LoginFlowConnector {
 	meta: ResolvedConnectorMeta;
 	connect: () => void;
 	isPending: boolean;
+	isConnecting: boolean;
 	error: Error | null;
 }
 
@@ -42,7 +43,11 @@ export interface UseLoginFlowReturn {
 export function useLoginFlow(
 	options?: UseLoginFlowOptions,
 ): UseLoginFlowReturn {
-	const { connect, connectors, isPending, error } = useConnect();
+	const { connect, connectors, isPending, error, variables } = useConnect();
+	const pendingConnector =
+		isPending && typeof variables?.connector === "object"
+			? variables.connector
+			: undefined;
 	const { address, isConnected } = useAccount();
 	const {
 		token,
@@ -61,6 +66,7 @@ export function useLoginFlow(
 			meta: resolveConnectorMeta(connector.name, options?.connectorMeta),
 			connect: () => connect({ connector }),
 			isPending,
+			isConnecting: pendingConnector?.uid === connector.uid,
 			error: (error as Error | null) ?? null,
 		})),
 		isConnected,

--- a/src/hooks/use-login-flow.ts
+++ b/src/hooks/use-login-flow.ts
@@ -1,0 +1,77 @@
+import type { UserInfo } from "@web3auth/base";
+import type { Connector } from "wagmi";
+import { useAccount, useConnect } from "wagmi";
+import {
+	type ConnectorMeta,
+	type ResolvedConnectorMeta,
+	resolveConnectorMeta,
+} from "../components/connector-meta";
+import { useAuth } from "./use-auth";
+
+export interface LoginFlowConnector {
+	connector: Connector;
+	meta: ResolvedConnectorMeta;
+	connect: () => void;
+	isPending: boolean;
+	error: Error | null;
+}
+
+export interface UseLoginFlowOptions {
+	connectorMeta?: Record<string, ConnectorMeta>;
+}
+
+export interface UseLoginFlowReturn {
+	connectors: LoginFlowConnector[];
+	isConnected: boolean;
+	address: `0x${string}` | undefined;
+	token: string | null;
+	signToken: () => void;
+	reSignToken: () => void;
+	signing: boolean;
+	signError: Error | null;
+	logout: () => void;
+	disableAuth: boolean;
+	web3AuthUser: Partial<UserInfo> | null;
+}
+
+/**
+ * Headless login flow: all the state and actions the styled `Login`
+ * component uses, with none of its markup. Build any UI on top.
+ * Must be used inside `IqLoginProvider`.
+ */
+export function useLoginFlow(
+	options?: UseLoginFlowOptions,
+): UseLoginFlowReturn {
+	const { connect, connectors, isPending, error } = useConnect();
+	const { address, isConnected } = useAccount();
+	const {
+		token,
+		signToken,
+		reSignToken,
+		loading,
+		error: authError,
+		logout,
+		disableAuth,
+		web3AuthUser,
+	} = useAuth();
+
+	return {
+		connectors: connectors.map((connector) => ({
+			connector,
+			meta: resolveConnectorMeta(connector.name, options?.connectorMeta),
+			connect: () => connect({ connector }),
+			isPending,
+			error: (error as Error | null) ?? null,
+		})),
+		isConnected,
+		address,
+		token,
+		signToken,
+		reSignToken,
+		signing: loading,
+		signError: (authError as Error | null) ?? null,
+		logout,
+		disableAuth,
+		web3AuthUser,
+	};
+}

--- a/src/hooks/use-login-flow.ts
+++ b/src/hooks/use-login-flow.ts
@@ -1,28 +1,18 @@
 import type { UserInfo } from "@web3auth/base";
-import type { Connector } from "wagmi";
 import { useAccount, useConnect } from "wagmi";
+import type { ConnectorRow } from "../components/login-element";
 import {
 	type ConnectorMeta,
-	type ResolvedConnectorMeta,
 	resolveConnectorMeta,
 } from "../components/connector-meta";
 import { useAuth } from "./use-auth";
-
-export interface LoginFlowConnector {
-	connector: Connector;
-	meta: ResolvedConnectorMeta;
-	connect: () => void;
-	isPending: boolean;
-	isConnecting: boolean;
-	error: Error | null;
-}
 
 export interface UseLoginFlowOptions {
 	connectorMeta?: Record<string, ConnectorMeta>;
 }
 
 export interface UseLoginFlowReturn {
-	connectors: LoginFlowConnector[];
+	connectors: ConnectorRow[];
 	isConnected: boolean;
 	address: `0x${string}` | undefined;
 	token: string | null;
@@ -67,7 +57,7 @@ export function useLoginFlow(
 			connect: () => connect({ connector }),
 			isPending,
 			isConnecting: pendingConnector?.uid === connector.uid,
-			error: (error as Error | null) ?? null,
+			error,
 		})),
 		isConnected,
 		address,
@@ -75,7 +65,7 @@ export function useLoginFlow(
 		signToken,
 		reSignToken,
 		signing: loading,
-		signError: (authError as Error | null) ?? null,
+		signError: authError,
 		logout,
 		disableAuth,
 		web3AuthUser,

--- a/src/lib/cn.ts
+++ b/src/lib/cn.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+	return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
*Closes https://github.com/IQIndustries/issues/issues/5147 when this PR merged*


## What

Makes the `Login` component's UI customizable per project while keeping the default look 100% unchanged for existing consumers, and adds a headless hook for apps that want to own the entire login UI.

### 1. `Login` customization props (all optional)

- `variant` — `"page"` (default, current layout) or `"card"` (renders only the card, so apps can place it in their own modal)
- `classNames` — per-slot class overrides across 27 named slots (`card`, `connectorButton`, `connectorLabel`, `signButton`, …), merged over the defaults with `tailwind-merge` so consumer classes win conflicts
- `connectorMeta` — override label/description/icon per connector (`Injected`, `WalletConnect`, `Web3Auth`)
- `header` / `footer` — ReactNode slots replacing the default heading block / rendering below the wallet list
- `renderConnector` — render-prop escape hatch for full control of each wallet row

### 2. Headless `useLoginFlow()` hook

Packages everything `Login` uses internally — connectors with resolved metadata, connect actions and pending/error state, `isConnected`/`address`, and the sign-token step (`token`, `signToken`, `signing`, `signError`, `logout`, `disableAuth`). Apps (inside or outside the IQ ecosystem) can build a fully custom login screen with zero library markup. Must be used inside `IqLoginProvider`.

## Backward compatibility

- `<Login />` with no props renders exactly as before — default class strings were extracted verbatim and verified character-for-character, plus side-by-side browser screenshot comparison against the previous release.
- No changes to hooks, config, provider, or server code paths. Existing exports untouched; new types (`LoginProps`, `LoginSlot`, `ConnectorMeta`, `ConnectorRow`, `LoginVariant`, `UseLoginFlowReturn`, …) exported from `@everipedia/iq-login/client`.
