### PR TITLE
ci(release): run release job on Node 20 + pnpm 10 to fix changesets E…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,9 @@ jobs:
       - name: Setup Node.js and pnpm
         uses: wyvox/action-setup-pnpm@v3
         with:
-          node-version: '18'
+          node-version: '20'
+          pnpm-version: 10
+          args: --frozen-lockfile
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets


### PR DESCRIPTION
## Summary

The Release job crashed in `changeset version` (`ERR_REQUIRE_ESM`): unpinned pnpm resolved to v8, which can't read our v9 lockfile, so CI fresh-resolved deps and pulled the ESM-only `human-id@4.2.0` — which Node 18 can't `require()`. This blocked the Version Packages PR (run 30482385656).

- Bump job to Node 20 (supports `require(ESM)`)
- Pin `pnpm-version: 10` + `--frozen-lockfile` so CI installs the locked CJS `human-id@4.1.1`

